### PR TITLE
Set socket mode version range

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 	implementation("com.slack.api:bolt:1.26.1")
 	implementation("com.slack.api:bolt-socket-mode:1.26.1")
 	implementation("javax.websocket:javax.websocket-api:1.1")
-	implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:1.19")
+	implementation("org.glassfish.tyrus.bundles:tyrus-standalone-client:(,1.19]")
 	// ***** OAUTH DEPENDENCIES *****
 	implementation("com.slack.api:bolt-jetty:1.26.1")
 	// ***** TEST DEPENDENCIES *****

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.glassfish.tyrus.bundles</groupId>
             <artifactId>tyrus-standalone-client</artifactId>
-            <version>1.19</version>
+            <version>(,1.19]</version>
         </dependency>
         <!-- ***** OAUTH DEPENDENCIES ***** -->
         <dependency>


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This pull request sets version range of the tyrus standalone client library. I am not still confident that this change can block dependabot's unnecessary PRs but having this change should be clearer for humans that bolt-socket-mode does not support v2 yet.

```
$ gradle dependencies

annotationProcessor - Annotation processors and their dependencies for source set 'main'.
No dependencies

apiElements - API elements for main. (n)
No dependencies

archives - Configuration for archive artifacts. (n)
No dependencies

compileClasspath - Compile classpath for source set 'main'.
+--- ch.qos.logback:logback-classic:1.4.4
|    +--- ch.qos.logback:logback-core:1.4.4
|    \--- org.slf4j:slf4j-api:2.0.1
+--- com.slack.api:bolt:1.26.1
|    +--- com.slack.api:slack-api-model:1.26.1
|    |    \--- com.google.code.gson:gson:2.9.1
|    +--- com.slack.api:slack-api-client:1.26.1
|    |    +--- com.slack.api:slack-api-model:1.26.1 (*)
|    |    +--- com.squareup.okhttp3:okhttp:4.10.0
|    |    |    +--- com.squareup.okio:okio:3.0.0
|    |    |    |    \--- com.squareup.okio:okio-jvm:3.0.0
|    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31
|    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.5.31 -> 1.6.20
|    |    |    |         |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.20
|    |    |    |         |    |    \--- org.jetbrains:annotations:13.0
|    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.31
|    |    |    |         |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.5.31 -> 1.6.20 (*)
|    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.31 -> 1.6.20
|    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.6.20 (*)
|    |    +--- com.google.code.gson:gson:2.9.1
|    |    \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.1
|    \--- com.slack.api:slack-app-backend:1.26.1
|         +--- com.slack.api:slack-api-model:1.26.1 (*)
|         +--- com.slack.api:slack-api-client:1.26.1 (*)
|         +--- com.squareup.okhttp3:okhttp:4.10.0 (*)
|         +--- com.google.code.gson:gson:2.9.1
|         \--- org.slf4j:slf4j-api:1.7.36 -> 2.0.1
+--- com.slack.api:bolt-socket-mode:1.26.1
|    +--- com.slack.api:slack-api-model:1.26.1 (*)
|    +--- com.slack.api:slack-api-client:1.26.1 (*)
|    +--- com.slack.api:slack-app-backend:1.26.1 (*)
|    \--- com.slack.api:bolt:1.26.1 (*)
+--- javax.websocket:javax.websocket-api:1.1
+--- org.glassfish.tyrus.bundles:tyrus-standalone-client:(,1.19] -> 1.19
\--- com.slack.api:bolt-jetty:1.26.1
     +--- com.slack.api:slack-api-model:1.26.1 (*)
     +--- com.slack.api:slack-api-client:1.26.1 (*)
     +--- com.slack.api:slack-app-backend:1.26.1 (*)
     +--- com.slack.api:bolt:1.26.1 (*)
     +--- com.slack.api:bolt-servlet:1.26.1
     |    +--- com.slack.api:slack-api-model:1.26.1 (*)
     |    +--- com.slack.api:slack-api-client:1.26.1 (*)
     |    +--- com.slack.api:slack-app-backend:1.26.1 (*)
     |    \--- com.slack.api:bolt:1.26.1 (*)
     +--- javax.servlet:javax.servlet-api:3.1.0
     +--- org.eclipse.jetty:jetty-servlet:9.4.48.v20220622
     |    +--- org.eclipse.jetty:jetty-security:9.4.48.v20220622
     |    |    \--- org.eclipse.jetty:jetty-server:9.4.48.v20220622
     |    |         +--- javax.servlet:javax.servlet-api:3.1.0
     |    |         +--- org.eclipse.jetty:jetty-http:9.4.48.v20220622
     |    |         |    +--- org.eclipse.jetty:jetty-util:9.4.48.v20220622
     |    |         |    \--- org.eclipse.jetty:jetty-io:9.4.48.v20220622
     |    |         |         \--- org.eclipse.jetty:jetty-util:9.4.48.v20220622
     |    |         \--- org.eclipse.jetty:jetty-io:9.4.48.v20220622 (*)
     |    \--- org.eclipse.jetty:jetty-util-ajax:9.4.48.v20220622
     |         \--- org.eclipse.jetty:jetty-util:9.4.48.v20220622
     +--- org.eclipse.jetty:jetty-server:9.4.48.v20220622 (*)
     \--- org.eclipse.jetty:jetty-webapp:9.4.48.v20220622
          +--- org.eclipse.jetty:jetty-xml:9.4.48.v20220622
          |    \--- org.eclipse.jetty:jetty-util:9.4.48.v20220622
          \--- org.eclipse.jetty:jetty-servlet:9.4.48.v20220622 (*)

(omitted)

$ mvn dependency:tree
[INFO] Scanning for projects...
[INFO]
[INFO] ---------------< org.example:bolt-java-starter-template >---------------
[INFO] Building bolt-java-starter-template 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ bolt-java-starter-template ---
[INFO] org.example:bolt-java-starter-template:jar:1.0-SNAPSHOT
[INFO] +- ch.qos.logback:logback-classic:jar:1.4.4:compile
[INFO] |  +- ch.qos.logback:logback-core:jar:1.4.4:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:2.0.1:compile
[INFO] +- com.slack.api:bolt:jar:1.26.1:compile
[INFO] |  +- com.slack.api:slack-api-model:jar:1.26.1:compile
[INFO] |  |  \- com.google.code.gson:gson:jar:2.9.1:compile
[INFO] |  +- com.slack.api:slack-api-client:jar:1.26.1:compile
[INFO] |  |  \- com.squareup.okhttp3:okhttp:jar:4.10.0:compile
[INFO] |  |     +- com.squareup.okio:okio-jvm:jar:3.0.0:compile
[INFO] |  |     |  +- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.5.31:compile
[INFO] |  |     |  |  \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.5.31:compile
[INFO] |  |     |  \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.5.31:compile
[INFO] |  |     \- org.jetbrains.kotlin:kotlin-stdlib:jar:1.6.20:compile
[INFO] |  |        \- org.jetbrains:annotations:jar:13.0:compile
[INFO] |  \- com.slack.api:slack-app-backend:jar:1.26.1:compile
[INFO] +- com.slack.api:bolt-socket-mode:jar:1.26.1:compile
[INFO] +- javax.websocket:javax.websocket-api:jar:1.1:compile
[INFO] +- org.glassfish.tyrus.bundles:tyrus-standalone-client:jar:1.19:compile
[INFO] +- com.slack.api:bolt-jetty:jar:1.26.1:compile
[INFO] |  +- com.slack.api:bolt-servlet:jar:1.26.1:compile
[INFO] |  +- javax.servlet:javax.servlet-api:jar:3.1.0:compile
[INFO] |  +- org.eclipse.jetty:jetty-servlet:jar:9.4.48.v20220622:compile
[INFO] |  |  +- org.eclipse.jetty:jetty-security:jar:9.4.48.v20220622:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.48.v20220622:compile
[INFO] |  |     \- org.eclipse.jetty:jetty-util:jar:9.4.48.v20220622:compile
[INFO] |  +- org.eclipse.jetty:jetty-server:jar:9.4.48.v20220622:compile
[INFO] |  |  +- org.eclipse.jetty:jetty-http:jar:9.4.48.v20220622:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-io:jar:9.4.48.v20220622:compile
[INFO] |  \- org.eclipse.jetty:jetty-webapp:jar:9.4.48.v20220622:compile
[INFO] |     \- org.eclipse.jetty:jetty-xml:jar:9.4.48.v20220622:compile
[INFO] +- org.junit.jupiter:junit-jupiter-engine:jar:5.9.1:test
[INFO] |  +- org.junit.platform:junit-platform-engine:jar:1.9.1:test
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |  |  \- org.junit.platform:junit-platform-commons:jar:1.9.1:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-api:jar:5.9.1:test
[INFO] |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO] \- org.mockito:mockito-core:jar:4.8.0:test
[INFO]    +- net.bytebuddy:byte-buddy:jar:1.12.14:test
[INFO]    +- net.bytebuddy:byte-buddy-agent:jar:1.12.14:test
[INFO]    \- org.objenesis:objenesis:jar:3.2:test
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.267 s
[INFO] Finished at: 2022-10-18T10:16:17+09:00
[INFO] ------------------------------------------------------------------------
```

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
