### PR TITLE
Group dependency updates of Bolt for Java packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     ignore:
       - dependency-name: "tyrus-standalone-client"
         versions: [ "2.x" ]
+    groups:
+      bolt-gradle:
+        patterns:
+          - "com.slack.api:bolt*"
   - package-ecosystem: "maven"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
     ignore:
       - dependency-name: "tyrus-standalone-client"
         versions: [ "2.x" ]
+    groups:
+      bolt-maven:
+        patterns:
+          - "bolt*"


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation
- [x] Dependencies

### Summary

This PR groups @dependabot PRs of Bolt for Java version bumps to reduce the number of PRs that need merging with package updates.

Notes on this feature can be found here: https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
