### PR TITLE
Group Bolt version bumps with Maven into a single @dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,4 +21,4 @@ updates:
     groups:
       bolt-maven:
         patterns:
-          - "bolt*"
+          - "com.slack.api:bolt*"


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [x] Dependencies

### Summary

This PR attempts to group Bolt version bumps with Maven into a single @dependabot grouping by using the `com.slack.api:bolt*` pattern. Matching patterns with a `pom.xml` can be a bit tricky...

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)