### PR TITLE
feat(manifest): set org_deploy_enabled to true to be org-ready

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -47,7 +47,7 @@
     "interactivity": {
       "is_enabled": true
     },
-    "org_deploy_enabled": false,
+    "org_deploy_enabled": true,
     "socket_mode_enabled": true,
     "token_rotation_enabled": false
   }


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This pull request updates the app manifest to make the app org-ready by default (`"org_deploy_enabled": true`).

This will have **no impact** on apps created and installed to **Standalone Workspaces** (e.g. Free, Pro, and Business+) or **Enterprise Workspaces**.

This will **resolve issues** for apps **created** and installed to **Enterprise Organizations** then granted to Enterprise Workspaces. The main way to create an app on an Enterprise Organization (rather than Enterprise Workspace) is with the Slack CLI, so this change will make the app template compatible with the latest Slack CLI.

#### Context

Historically, we set this property to false because org-ready apps did not support incoming webhooks, which is a popular feature for developers. Recently, Slack Platform released support for incoming webhooks in org-ready apps and the adoption has been successful. So, going forward all of our app templates will be org-ready.

### Testing

_Did not manually test._

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
