### PR TITLE
fix: broken gradle CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Lint
         run: gradle spotlessCheck
       - name: Build & Test
-        run: gradle test -x spotlessApply
+        run: gradle test -x spotlessApply --info

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: ['11', '17']
+        java-version: ['17', '21']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: ['11', '17']
+        java-version: ['11', '17', '21']
 
     steps:
       - uses: actions/checkout@v4

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
 plugins {
 	id 'application'
 	id "com.diffplug.spotless" version "7.2.1"
+	id 'jvm-test-suite'
 }
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_11
-	targetCompatibility = JavaVersion.VERSION_11
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 }
 
 repositories {
@@ -22,7 +23,8 @@ dependencies {
 	// ***** OAUTH DEPENDENCIES *****
 	implementation("com.slack.api:bolt-jetty:1.45.3")
 	// ***** TEST DEPENDENCIES *****
-	testImplementation('org.junit.jupiter:junit-jupiter-engine:5.13.4')
+	testImplementation('org.junit.jupiter:junit-jupiter-api:5.13.4')
+	testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.13.4')
 	testImplementation('org.mockito:mockito-core:5.18.0')
 }
 
@@ -30,8 +32,12 @@ application {
 	mainClass = 'Main'
 }
 
-tasks.named('test') {
-	useJUnit()
+testing {
+	suites {
+		test {
+			useJUnitJupiter()
+		}
+	}
 }
 
 spotless {


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

The CI pipeline is currently reporting `Gradle requires JVM 17 or later to run. Your build is currently configured to use JVM 11.` This aims to fix this issue

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
