### PR TITLE
fix: spotless 3 no longer supports java 11

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,6 @@ jobs:
         java-version:
           - "17"
           - "21"
-          - "25"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -13,7 +13,6 @@ jobs:
         java-version:
           - "17"
           - "21"
-          - "25"
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
### Type of change <!-- place an x in the [ ] that applies -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

These changes update the java version tested in our CI, spotless no longer supports java 11

### Requirements <!-- place an x in each [ ] that applies -->

- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
